### PR TITLE
Years display + sample size note

### DIFF
--- a/app/Models/IndicatorValue.php
+++ b/app/Models/IndicatorValue.php
@@ -94,7 +94,7 @@ class IndicatorValue extends Model
     {
         return $this->years->map(function ($year) {
             return $year->year;
-        })->join(', ');
+        })->join(' - ');
     }
 
     public function getSubCharacteristicIdAttribute()

--- a/resources/js/components/elements/IndicatorValuesPreviewPane.vue
+++ b/resources/js/components/elements/IndicatorValuesPreviewPane.vue
@@ -34,7 +34,7 @@
                     <small
                         v-if="row.item.sample_size && row.item.sample_size < 21"
                         class="mr-2"
-                    > (Note: Small sample!)</s>
+                    > (Note: Small sample!)
                     </small>
                 </span>
             </template>

--- a/resources/js/components/elements/IndicatorValuesPreviewPane.vue
+++ b/resources/js/components/elements/IndicatorValuesPreviewPane.vue
@@ -30,9 +30,9 @@
                 {{ row.item.source_public == 1 ? 'Yes' : 'No' }}
             </template>
             <template #cell(sample_size)="row">
-                <span :class="row.item.sample_size < 21 ? 'text-danger' : ''">{{ row.item.sample_size }}
+                <span :class="row.item.sample_size && row.item.sample_size < 21 ? 'text-danger' : ''">{{ row.item.sample_size }}
                     <small
-                        v-if="row.item.sample_size < 21"
+                        v-if="row.item.sample_size && row.item.sample_size < 21"
                         class="mr-2"
                     > (Note: Small sample!)</s>
                     </small>


### PR DESCRIPTION
2 minor visual fixes:
 - Years are now in the format 2010 - 2011 instead of 2010, 2011
 - small sample size note no longer appears when the sample size is null.