### PR TITLE
Conversion rate getter

### DIFF
--- a/app/Exports/IndicatorValuesExport.php
+++ b/app/Exports/IndicatorValuesExport.php
@@ -112,7 +112,7 @@ class IndicatorValuesExport implements FromCollection, WithHeadings, WithMapping
             $value->unit->unit,
             $value->converted_value,
             $value->standard_unit,
-            $value->unit->to_standard,
+            $value->conversion_rate,
             $value->purposeOfCollection->name,
             $value->sample_size,
             $value->definition,

--- a/app/Http/Controllers/Admin/IndicatorValueCrudController.php
+++ b/app/Http/Controllers/Admin/IndicatorValueCrudController.php
@@ -170,7 +170,7 @@ class IndicatorValueCrudController extends CrudController
                 'inline_create' => [ 'entity' => 'indicator' ],
                 'minimum_input_length' => 0,
                 'label' => 'Indicator',
-                'hint' => 'If the indicator is not in the dropdown select <br>+Add</br> to add a new one.',
+                'hint' => 'If the indicator is not in the dropdown select <b>+Add</b> to add a new one.',
             ],
             [
                 'name' => 'value',

--- a/app/Http/Controllers/Admin/IndicatorValueCrudController.php
+++ b/app/Http/Controllers/Admin/IndicatorValueCrudController.php
@@ -93,7 +93,7 @@ class IndicatorValueCrudController extends CrudController
             [
                 'name' => 'conversion_rate',
                 'type' => 'text',
-                'label' => 'Conversion Ratio used',
+                'label' => 'Conversion Ratio <br/>(original to standard)',
             ],
             [
                 'name' => 'years',
@@ -170,7 +170,7 @@ class IndicatorValueCrudController extends CrudController
                 'inline_create' => [ 'entity' => 'indicator' ],
                 'minimum_input_length' => 0,
                 'label' => 'Indicator',
-                'hint' => 'If the indicator is not in the dropdown select <b>+Add</b> to add a new one.',
+                'hint' => 'If the indicator is not in the dropdown select <br>+Add</br> to add a new one.',
             ],
             [
                 'name' => 'value',

--- a/app/Models/IndicatorValue.php
+++ b/app/Models/IndicatorValue.php
@@ -124,7 +124,7 @@ class IndicatorValue extends Model
 
     public function getConversionRateAttribute()
     {
-        return $this->unit ? $this->unit->conversion_rate : null;
+        return $this->unit ? $this->unit->getConversionRate($this->years->last()) : null;
     }
 
     public function getStandardUnitAttribute()

--- a/app/Models/IndicatorValue.php
+++ b/app/Models/IndicatorValue.php
@@ -138,21 +138,7 @@ class IndicatorValue extends Model
 
     public function getConvertedValueAttribute()
     {
-        // If the unit has a different conversion rate per year...
-        if ($this->unit && $this->unit->unitType && $this->unit->unitType->split_by_year && $this->years->count() > 0) {
-            $to_standard = $this->unit->getConverstionRateForYear($this->years->sortBy('year')->last());
-            return $this->value * $to_standard;
-        }
-
-        // ...else calculate value from the static conversion rate
-        $unit_standard = $this->unit ? $this->unit->to_standard : null;
-        if ($unit_standard) {
-            return $this->value * $this->unit->to_standard;
-        }
-        $unit_from_standard = $this->unit ? $this->unit->from_standard : null;
-        if ($unit_from_standard) {
-            return $this->value / $this->unit->from_standard;
-        }
+        return $this->value * $this->conversion_rate;
     }
 
 

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -41,15 +41,15 @@ class Unit extends Model
             if ($year == null) {
                 return 'varies-by-year';
             }
-            return '1:'. $this->clean_num($this->getConverstionRateForYear($year));
+            return $this->clean_num($this->getConverstionRateForYear($year));
         }
 
         if ($this->from_standard) {
-            return $this->clean_num($this->from_standard) . ':1';
+            return $this->clean_num(1 / $this->from_standard);
         }
 
         if ($this->to_standard) {
-            return '1:'. $this->clean_num($this->to_standard);
+            return $this->clean_num($this->to_standard);
         }
     }
 

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -35,19 +35,29 @@ class Unit extends Model
     |--------------------------------------------------------------------------
     */
 
-    // Getter for Crud Column
-    public function getConversionRateAttribute()
+    public function getConversionRate(Year $year = null)
     {
         if ($this->unitType && $this->unitType->split_by_year) {
-            return 'varies-by-year';
+            if ($year == null) {
+                return 'varies-by-year';
+            }
+            return '1:'. $this->clean_num($this->getConverstionRateForYear($year));
         }
+
         if ($this->from_standard) {
             return $this->clean_num($this->from_standard) . ':1';
         }
+
         if ($this->to_standard) {
             return '1:'. $this->clean_num($this->to_standard);
         }
     }
+
+    public function getConversionRateAttribute()
+    {
+        return $this->getConversionRate(null);
+    }
+
 
     // Getter for Crud Field
     public function getConversionYearsAttribute()


### PR DESCRIPTION
Splits + tidies conversion rate handling for IndicatorValue. This lets us to easily get the conversion rate used for any value, both on the front-end and in the export, and it's also a nice refactor of the IndicatorValue and Unit methods! 

The conversion rate should now correctly appear in the export as the "to_standard" multiplier. It's also available ready for updating the front-end. 