### PR TITLE
Unit naming + front-end preview of original vs standard 

### DIFF
--- a/app/Exports/IndicatorValuesExport.php
+++ b/app/Exports/IndicatorValuesExport.php
@@ -109,7 +109,7 @@ class IndicatorValuesExport implements FromCollection, WithHeadings, WithMapping
             $value->all_years,
             $value->gender->name,
             $value->value,
-            $value->unit->unit,
+            $value->unit->name,
             $value->converted_value,
             $value->standard_unit,
             $value->unit->to_standard,

--- a/app/Models/IndicatorValue.php
+++ b/app/Models/IndicatorValue.php
@@ -141,6 +141,12 @@ class IndicatorValue extends Model
         return $this->value * $this->conversion_rate;
     }
 
+    // TODO: understand the mathematical difference between "20" and "20.0" and if this difference is important in this platform...
+    public function getValueAttribute($value)
+    {
+        return $value + 0; // trick to force removal of excess zeros from the decimal stored in the db.
+    }
+
 
 
 

--- a/app/Models/IndicatorValue.php
+++ b/app/Models/IndicatorValue.php
@@ -139,27 +139,25 @@ class IndicatorValue extends Model
 
     public function getConvertedValueAttribute()
     {
-        $precision = $this->precision < 2 ? 2 : $this->precision;
-
-        return round($this->value * $this->conversion_rate, $precision);
+        return round($this->value * $this->conversion_rate, 2) + 0;
     }
 
-    // TODO: understand the mathematical difference between "20" and "20.0" and if this difference is important in this platform...
     public function getValueAttribute($value)
     {
         return $value + 0; // trick to force removal of excess zeros from the decimal stored in the db.
     }
 
-    public function getPrecisionAttribute()
-    {
-        $value = $this->value + 0;
+    // TODO: understand the mathematical difference between "20" and "20.0" and if this difference is important in this platform...
+    // public function getPrecisionAttribute()
+    // {
+    //     $value = $this->value + 0;
 
-        if (Str::contains($value, '.')) {
-            return Str::length(Str::afterLast($value, '.'));
-        }
+    //     if (Str::contains($value, '.')) {
+    //         return Str::length(Str::afterLast($value, '.'));
+    //     }
 
-        return 0;
-    }
+    //     return 0;
+    // }
 
 
 

--- a/app/Models/IndicatorValue.php
+++ b/app/Models/IndicatorValue.php
@@ -6,6 +6,7 @@ use Laravel\Scout\Searchable;
 use Illuminate\Database\Eloquent\Model;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Str;
 
 class IndicatorValue extends Model
 {
@@ -138,7 +139,9 @@ class IndicatorValue extends Model
 
     public function getConvertedValueAttribute()
     {
-        return $this->value * $this->conversion_rate;
+        $precision = $this->precision < 2 ? 2 : $this->precision;
+
+        return round($this->value * $this->conversion_rate, $precision);
     }
 
     // TODO: understand the mathematical difference between "20" and "20.0" and if this difference is important in this platform...
@@ -146,6 +149,18 @@ class IndicatorValue extends Model
     {
         return $value + 0; // trick to force removal of excess zeros from the decimal stored in the db.
     }
+
+    public function getPrecisionAttribute()
+    {
+        $value = $this->value + 0;
+
+        if (Str::contains($value, '.')) {
+            return Str::length(Str::afterLast($value, '.'));
+        }
+
+        return 0;
+    }
+
 
 
 

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\UnitType;
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Traits\UpdatesMainSearchIndex;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
@@ -27,6 +28,7 @@ class Unit extends Model
     // protected $dates = [];
     protected $appends = [
         'conversion_rate',
+        'name',
     ];
 
     /*
@@ -34,6 +36,13 @@ class Unit extends Model
     | FUNCTIONS
     |--------------------------------------------------------------------------
     */
+
+    // Unit name without appended "-customtype" for front-end
+    public function getNameAttribute()
+    {
+        return Str::before($this->unit, '-');
+    }
+
 
     // Getter for Crud Column
     public function getConversionRateAttribute()

--- a/resources/js/components/elements/IndicatorValuesPreviewPane.vue
+++ b/resources/js/components/elements/IndicatorValuesPreviewPane.vue
@@ -58,16 +58,18 @@
         </b-table>
 
         <template #modal-footer>
-            <div>When downloading data to Excel, both original and standardised values will be included.</div>
-            <b-button
-                size="sm"
-                variant="info"
-                class="ml-2 pr-2 font-weight-bold"
-                @click="toggleUnits"
-            >
-                <span v-if="!showStandardUnit">Show values in standardised units</span>
-                <span v-if="showStandardUnit">Show values in original unit</span>
-            </b-button>
+            <template v-if="conversionNeeded">
+                <div>When downloading data to Excel, both original and standardised values will be included.</div>
+                <b-button
+                    size="sm"
+                    variant="info"
+                    class="ml-2 pr-2 font-weight-bold"
+                    @click="toggleUnits"
+                >
+                    <span v-if="!showStandardUnit">Show values in standardised units</span>
+                    <span v-if="showStandardUnit">Show values in original unit</span>
+                </b-button>
+            </template>
             <b-button
                 size="sm"
                 :variant="selected ? 'info' : 'primary'"
@@ -116,6 +118,7 @@
         data() {
             return {
                 showStandardUnit: false,
+                conversionNeeded: false,
                 fields: [
                     {
                         key: "geo_boundary.country.name",
@@ -144,6 +147,20 @@
                     }
                 ]
             };
+        },
+
+        watch: {
+            indicator() {
+                this.conversionNeeded = this.values.some((value) => {
+                    console.log(value)
+                    return (
+                        value.conversion_rate != 1 &&
+                        value.conversion_rate != "1:1" &&
+                        value.conversion_rate != null
+                    )
+                })
+            }
+
         },
 
         methods: {

--- a/resources/js/components/elements/IndicatorValuesPreviewPane.vue
+++ b/resources/js/components/elements/IndicatorValuesPreviewPane.vue
@@ -47,10 +47,6 @@
                     </small>
                 </span>
             </template>
-            <template #head(value)="row">
-                <span v-if="!showStandardUnit">Value</span>
-                <span v-if="showStandardUnit">Converted Value</span>
-            </template>
             <template #cell(value)="row">
                 <span v-if="!showStandardUnit">{{ row.item.value }}</span>
                 <span v-if="showStandardUnit">{{ row.item.conversion_rate ? row.item.converted_value : '-' }}</span>

--- a/resources/js/components/elements/IndicatorValuesPreviewPane.vue
+++ b/resources/js/components/elements/IndicatorValuesPreviewPane.vue
@@ -17,7 +17,7 @@
             v-if="indicator"
             class="py-4"
         >
-            {{ indicator.code + ' - ' + indicator.name }}
+            {{ indicator.code + " - " + indicator.name }}
         </h3>
         <b-table
             class="mt-4 mb-2"
@@ -27,14 +27,21 @@
             thead-class="bg-light open-top"
         >
             <template #cell(source_public)="row">
-                {{ row.item.source_public == 1 ? 'Yes' : 'No' }}
+                {{ row.item.source_public == 1 ? "Yes" : "No" }}
             </template>
             <template #cell(sample_size)="row">
-                <span :class="row.item.sample_size && row.item.sample_size < 21 ? 'text-danger' : ''">{{ row.item.sample_size }}
+                <span
+                    :class="
+                        row.item.sample_size && row.item.sample_size < 21
+                            ? 'text-danger'
+                            : ''
+                    "
+                >{{ row.item.sample_size }}
                     <small
                         v-if="row.item.sample_size && row.item.sample_size < 21"
                         class="mr-2"
-                    > (Note: Small sample!)
+                    >
+                        (Note: Small sample!)
                     </small>
                 </span>
             </template>
@@ -70,61 +77,60 @@
         props: {
             values: {
                 type: Array,
-                default: () => [],
+                default: () => []
             },
             id: {
                 type: String,
-                default: 'valuepreview',
+                default: "valuepreview"
             },
             indicator: {
                 type: Object,
-                default: null,
+                default: null
             },
             selected: {
                 type: Boolean,
-                default: null,
+                default: null
             }
         },
         data() {
             return {
                 fields: [
                     {
-                        key: 'geo_boundary.country.name',
-                        label: 'Country',
+                        key: "geo_boundary.country.name",
+                        label: "Country"
                     },
                     {
-                        key: 'all_years',
-                        label: 'Year',
+                        key: "all_years",
+                        label: "Year"
                     },
-                    'value',
+                    "value",
                     {
-                        key: 'unit.unit',
-                        label: 'Unit'
-                    },
-                    {
-                        key: 'sample_size',
-                        label: 'Sample size',
+                        key: "unit.name",
+                        label: "Unit"
                     },
                     {
-                        key: 'gender.name',
-                        label: 'Gender',
+                        key: "sample_size",
+                        label: "Sample size"
                     },
                     {
-                        key: 'purpose_of_collection.name',
-                        label: 'Purpose of collection',
+                        key: "gender.name",
+                        label: "Gender"
+                    },
+                    {
+                        key: "purpose_of_collection.name",
+                        label: "Purpose of collection"
                     }
                 ]
-            }
+            };
         },
 
         methods: {
             downloadValues() {
-                this.$emit('download', [this.indicator]);
+                this.$emit("download", [this.indicator]);
             },
             toggleIndicatorSelection() {
-                this.$emit('toggle-indicator', this.indicator);
+                this.$emit("toggle-indicator", this.indicator);
             }
         }
-
-    }
+    };
 </script>

--- a/resources/js/components/elements/IndicatorValuesPreviewPane.vue
+++ b/resources/js/components/elements/IndicatorValuesPreviewPane.vue
@@ -47,9 +47,17 @@
                     </small>
                 </span>
             </template>
+            <template #head(value)="row">
+                <span v-if="!showStandardUnit">Value</span>
+                <span v-if="showStandardUnit">Converted Value</span>
+            </template>
             <template #cell(value)="row">
                 <span v-if="!showStandardUnit">{{ row.item.value }}</span>
                 <span v-if="showStandardUnit">{{ row.item.conversion_rate ? row.item.converted_value : '-' }}</span>
+            </template>
+            <template #head(unit)="row">
+                <span v-if="!showStandardUnit">Unit</span>
+                <span v-if="showStandardUnit">Standard Unit</span>
             </template>
             <template #cell(unit)="row">
                 <span v-if="!showStandardUnit">{{ row.item.unit.name }}</span>

--- a/resources/js/components/elements/IndicatorValuesPreviewPane.vue
+++ b/resources/js/components/elements/IndicatorValuesPreviewPane.vue
@@ -49,7 +49,7 @@
             </template>
             <template #cell(value)="row">
                 <span v-if="!showStandardUnit">{{ row.item.value }}</span>
-                <span v-if="showStandardUnit">{{ row.item.conversion_rate ? (Math.round(row.item.converted_value * 100) / 100).toFixed(2) : '-' }}</span>
+                <span v-if="showStandardUnit">{{ row.item.conversion_rate ? row.item.converted_value : '-' }}</span>
             </template>
             <template #cell(unit)="row">
                 <span v-if="!showStandardUnit">{{ row.item.unit.name }}</span>

--- a/resources/js/components/elements/IndicatorValuesPreviewPane.vue
+++ b/resources/js/components/elements/IndicatorValuesPreviewPane.vue
@@ -171,6 +171,14 @@
 
         },
 
+        mounted() {
+            this.$root.$on('bv::modal::hidden', (bvEvent, modelId) => {
+                if(modelId === "valuePreviewModal") {
+                    this.showStandardUnit = false;
+                }
+            });
+        },
+
         methods: {
             downloadValues() {
                 this.$emit("download", [this.indicator]);

--- a/resources/js/components/elements/IndicatorValuesPreviewPane.vue
+++ b/resources/js/components/elements/IndicatorValuesPreviewPane.vue
@@ -49,7 +49,7 @@
             </template>
             <template #cell(value)="row">
                 <span v-if="!showStandardUnit">{{ row.item.value }}</span>
-                <span v-if="showStandardUnit">{{ row.item.conversion_rate ? Math.round(row.item.converted_value * 100) / 100 : '-' }}</span>
+                <span v-if="showStandardUnit">{{ row.item.conversion_rate ? (Math.round(row.item.converted_value * 100) / 100).toFixed(2) : '-' }}</span>
             </template>
             <template #cell(unit)="row">
                 <span v-if="!showStandardUnit">{{ row.item.unit.name }}</span>

--- a/resources/js/components/elements/IndicatorValuesPreviewPane.vue
+++ b/resources/js/components/elements/IndicatorValuesPreviewPane.vue
@@ -7,8 +7,10 @@
         header-bg-variant="primary"
         header-text-variant="light"
     >
-        <template #modal-title>
-            <h2 class="font-weight-bold">
+        <template
+            #modal-title
+        >
+            <h2 class="font-weight-bold w-75">
                 Indicator Values Preview
             </h2>
         </template>
@@ -45,9 +47,27 @@
                     </small>
                 </span>
             </template>
+            <template #cell(value)="row">
+                <span v-if="!showStandardUnit">{{ row.item.value }}</span>
+                <span v-if="showStandardUnit">{{ row.item.conversion_rate ? Math.round(row.item.converted_value * 100) / 100 : '-' }}</span>
+            </template>
+            <template #cell(unit)="row">
+                <span v-if="!showStandardUnit">{{ row.item.unit.name }}</span>
+                <span v-if="showStandardUnit">{{ row.item.standard_unit }}</span>
+            </template>
         </b-table>
 
         <template #modal-footer>
+            <div>When downloading data to Excel, both original and standardised values will be included.</div>
+            <b-button
+                size="sm"
+                variant="info"
+                class="ml-2 pr-2 font-weight-bold"
+                @click="toggleUnits"
+            >
+                <span v-if="!showStandardUnit">Show values in standardised units</span>
+                <span v-if="showStandardUnit">Show values in original unit</span>
+            </b-button>
             <b-button
                 size="sm"
                 :variant="selected ? 'info' : 'primary'"
@@ -67,6 +87,7 @@
                 @click="downloadValues"
             >
                 <i class="las la-download" />
+            </b-button>
             </b-button>
         </template>
     </b-modal>
@@ -90,10 +111,11 @@
             selected: {
                 type: Boolean,
                 default: null
-            }
+            },
         },
         data() {
             return {
+                showStandardUnit: false,
                 fields: [
                     {
                         key: "geo_boundary.country.name",
@@ -105,7 +127,7 @@
                     },
                     "value",
                     {
-                        key: "unit.name",
+                        key: "unit",
                         label: "Unit"
                     },
                     {
@@ -130,7 +152,11 @@
             },
             toggleIndicatorSelection() {
                 this.$emit("toggle-indicator", this.indicator);
+            },
+            toggleUnits() {
+                this.showStandardUnit = !this.showStandardUnit;
             }
+
         }
     };
 </script>


### PR DESCRIPTION
This updates the front-end and export to show the unit name without any appended "-standardunit", so for e.g.: 
 - quintal
 - qunital-kg

...would both appear as "quintal" when presented to the user. This is a workaround as eventually we want a system where the user can convert more freely between unit types. 

This also includes the ability for users to toggle between viewing the original values and the converted values in the preview panel on the front-end (and adds a note to say both values are present in the download).