### PR TITLE
Filter fix + adding Excel file ref into R script

### DIFF
--- a/app/Exports/IndicatorValuesExport.php
+++ b/app/Exports/IndicatorValuesExport.php
@@ -15,6 +15,8 @@ class IndicatorValuesExport implements FromCollection, WithHeadings, WithMapping
     public $years = null;
     public $types = null;
     public $purposes = null;
+    public $genders = null;
+    public $scopes = null;
 
 
     // Setters
@@ -46,6 +48,18 @@ class IndicatorValuesExport implements FromCollection, WithHeadings, WithMapping
     public function forPurposes(array $purposes)
     {
         $this->purposes = count($purposes) > 0 ? $purposes : null;
+        return $this;
+    }
+
+    public function forGenders(array $genders)
+    {
+        $this->genders = count($genders) > 0 ? $genders : null;
+        return $this;
+    }
+
+    public function forScopes(array $scopes)
+    {
+        $this->scopes = count($scopes) > 0 ? $scopes : null;
         return $this;
     }
 
@@ -93,6 +107,18 @@ class IndicatorValuesExport implements FromCollection, WithHeadings, WithMapping
         if ($this->purposes) {
             $query = $query->whereHas('purposeOfCollection', function (Builder $query) {
                 $query->whereIn('purpose_of_collections.id', $this->purposes);
+            });
+        }
+
+        if ($this->genders) {
+            $query = $query->whereHas('gender', function (Builder $query) {
+                $query->whereIn('genders.id', $this->genders);
+            });
+        }
+
+        if ($this->scopes) {
+            $query = $query->whereHas('scope', function (Builder $query) {
+                $query->whereIn('scopes.id', $this->scopes);
             });
         }
 

--- a/app/Http/Controllers/IndicatorValueController.php
+++ b/app/Http/Controllers/IndicatorValueController.php
@@ -87,10 +87,12 @@ class IndicatorValueController extends Controller
 
     public function report(Request $request)
     {
+        $excelPath = $this->download($request);
+
         $indicatorValueIds = Collect($request->input('indicator_values'))->pluck('id')->toArray();
         $indicatorValueIds = implode(",", $indicatorValueIds);
 
-        $process = new Process(['Rscript', 'makeReport.R', $indicatorValueIds]);
+        $process = new Process(['Rscript', 'makeReport.R', $excelPath, $indicatorValueIds]);
         $process->setWorkingDirectory(base_path('scripts/Rscript'));
 
         $process->run();

--- a/app/Http/Controllers/IndicatorValueController.php
+++ b/app/Http/Controllers/IndicatorValueController.php
@@ -65,8 +65,17 @@ class IndicatorValueController extends Controller
             $export = $export->forPurposes($request->input('purposes'));
         }
 
+        if ($request->has('genders') && count($request->input('genders')) > 0) {
+            $export = $export->forGenders($request->input('genders'));
+        }
+
+        if ($request->has('scopes') && count($request->input('scopes')) > 0) {
+            $export = $export->forScopes($request->input('scopes'));
+        }
+
+
         $filename = 'indicator-values-exports/indicator-values-'.now()->format('Y-M-D_his').'.xlsx';
-   
+
         $success = Excel::store($export, $filename, 'public');
 
         if (! $success) {

--- a/database/factories/SourceFactory.php
+++ b/database/factories/SourceFactory.php
@@ -26,7 +26,6 @@ class SourceFactory extends Factory
         return [
             'name' => $this->faker->unique()->word(),
             'reference' => $this->faker->sentence(2),
-            'type_id' => 1,
             'partner_id' => Partner::factory(),
             'description' => $this->faker->paragraph(5),
             'is_not_public' => $this->faker->boolean,

--- a/resources/js/components/IndicatorHub.vue
+++ b/resources/js/components/IndicatorHub.vue
@@ -97,9 +97,7 @@
                 <!-- </characteristics> -->
                 <!-- <sub-characteristics> -->
                 <div v-if="selectedCharacteristic">
-                    <h2 class="pt-3">
-                        
-                    </h2>
+                    <h2 class="pt-3" />
                     <div class="d-flex flex-wrap">
                         <b-form-checkbox-group
                             v-model="selectedSubCharacteristics"
@@ -488,6 +486,8 @@
                         years: this.selectedYears,
                         types: this.selectedTypes,
                         purposes: this.selectedPurposes,
+                        genders: this.selectedGenders,
+                        scopes: this.selectedScopes,
                     })
                     .then(result => {
                         this.makeAndClickLink(result.data);

--- a/resources/js/components/IndicatorHub.vue
+++ b/resources/js/components/IndicatorHub.vue
@@ -513,6 +513,13 @@
                 axios
                     .post("indicators/report", {
                         indicator_values: indicatorValues,
+                        indicators: selectedIndicators,
+                        countries: this.selectedCountries,
+                        years: this.selectedYears,
+                        types: this.selectedTypes,
+                        purposes: this.selectedPurposes,
+                        genders: this.selectedGenders,
+                        scopes: this.selectedScopes
                     })
                     .then(result => {
                         this.makeAndClickLink(result.data);

--- a/resources/js/components/elements/IndicatorValuesPreviewPane.vue
+++ b/resources/js/components/elements/IndicatorValuesPreviewPane.vue
@@ -117,7 +117,7 @@
             selected: {
                 type: Boolean,
                 default: null
-            },
+            }
         },
         data() {
             return {
@@ -155,21 +155,20 @@
 
         watch: {
             indicator() {
-                this.conversionNeeded = this.values.some((value) => {
-                    console.log(value)
+                this.conversionNeeded = this.values.some(value => {
+                    console.log(value);
                     return (
                         value.conversion_rate != 1 &&
                         value.conversion_rate != "1:1" &&
                         value.conversion_rate != null
-                    )
-                })
+                    );
+                });
             }
-
         },
 
         mounted() {
-            this.$root.$on('bv::modal::hidden', (bvEvent, modelId) => {
-                if(modelId === "valuePreviewModal") {
+            this.$root.$on("bv::modal::hidden", (bvEvent, modelId) => {
+                if (modelId === "valuePreviewModal") {
                     this.showStandardUnit = false;
                 }
             });
@@ -177,7 +176,7 @@
 
         methods: {
             downloadValues() {
-                this.$emit("download", [this.indicator]);
+                this.$emit("download", [this.indicator.id]);
             },
             toggleIndicatorSelection() {
                 this.$emit("toggle-indicator", this.indicator);
@@ -185,7 +184,6 @@
             toggleUnits() {
                 this.showStandardUnit = !this.showStandardUnit;
             }
-
         }
     };
 </script>

--- a/scripts/Rscript/IndicatorStatement.R
+++ b/scripts/Rscript/IndicatorStatement.R
@@ -1,10 +1,14 @@
 library(tidyverse)
 library(RMariaDB)
 library(dotenv)
+library(readxl)
 
 args <- commandArgs(TRUE)
 
-indicator_value_ids <- strsplit(args[1], ',')
+excelFile <- args[1]
+excelData <- read_excel(excelFile)
+
+indicator_value_ids <- strsplit(args[2], ',')
 indicator_value_ids <- indicator_value_ids[!is.na(indicator_value_ids)]
 indicator_value_ids <- as.integer(indicator_value_ids[[1]])
 # dotenv::load_dot_env("../../.env")


### PR DESCRIPTION
This PR fixes the Gender and Scope filters to correctly filter the contents of the Excel download. 

It also tweaks the R reporting, so that the same Excel file is generated first and then loaded into R with read_excel(). The reason for this is to give R access to the variables that are calculated in PHP (and not present in the database), e.g. the converted_value. 

