### PR TITLE
Search

### DIFF
--- a/app/Http/Controllers/IndicatorValueController.php
+++ b/app/Http/Controllers/IndicatorValueController.php
@@ -24,12 +24,12 @@ class IndicatorValueController extends Controller
     public function index(Request $request)
     {
         if ($request->has('search')) {
-            $query = IndicatorValue::search($request->search);
+            $query = IndicatorValue::search($request->search)->paginate(0);
         } else {
-            $query = IndicatorValue::query();
+            $query = IndicatorValue::query()->get();
         }
 
-        $results = $query->get()->load('purposeOfCollection', 'indicator.subCharacteristic.characteristic', 'gender', 'scope');
+        $results = $query->load('purposeOfCollection', 'indicator.subCharacteristic.characteristic', 'gender', 'scope');
 
         return $results;
     }

--- a/resources/js/components/IndicatorHub.vue
+++ b/resources/js/components/IndicatorHub.vue
@@ -152,6 +152,8 @@
                         :items="indicatorsForDisplay"
                         :fields="indicatorFields"
                         :busy="loading"
+                        :sort-by.sync="sortBy"
+                        :sort-desc.sync="sortDesc"
                         sticky-header
                         class="pb-4"
                         thead-class="bg-light open-top"
@@ -247,6 +249,8 @@
 
         data() {
             return {
+                sortBy: 'code',
+                sortDesc: false,
                 processing: false,
                 loading: false,
                 downloadOptionsVisible: false,
@@ -256,11 +260,13 @@
                 indicatorFields: [
                     {
                         key: "code",
-                        label: "Code"
+                        label: "Code",
+                        sortable: true,
                     },
                     {
                         key: "name",
-                        label: "Indicator"
+                        label: "Indicator",
+                        sortable: true,
                     },
                     {
                         key: "actions",


### PR DESCRIPTION
This PR fixes the search box on the front-end indicator hub. It also pre-sorts indicators by code, and allows dynamic sorting by code and name within the table. 