### PR TITLE
fix for 0s becoming empty (null) values in export

### DIFF
--- a/app/Exports/IndicatorValuesExport.php
+++ b/app/Exports/IndicatorValuesExport.php
@@ -9,7 +9,7 @@ use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithStrictNullComparison;
 
-class IndicatorValuesExport implements FromCollection, WithHeadings, WithMapping
+class IndicatorValuesExport implements FromCollection, WithHeadings, WithMapping, WithStrictNullComparison
 {
     public $indicators = null;
     public $countries = null;

--- a/app/Exports/IndicatorValuesExport.php
+++ b/app/Exports/IndicatorValuesExport.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Concerns\WithStrictNullComparison;
 
 class IndicatorValuesExport implements FromCollection, WithHeadings, WithMapping
 {


### PR DESCRIPTION
This tiny PR fixes the issue where values of 0 are treated as nulls and left as empty cells in the Excel Indicator Value export. 